### PR TITLE
fix: link to eodag providers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Specific to Copernicus Sentinel data discovery, download and processing.
 - [**`sentinel2_aws`**](https://github.com/beaorn/sentinel2_aws)
   - Ruby gem for parsing Sentinel-2 metadata from AWS
 - [**`eodag`**](https://github.com/CS-SI/eodag)
-  - command line tool and plugin-oriented Python framework for search and download from [multiple providers](https://eodag.readthedocs.io/en/latest/intro.html#available-providers) including all DIAS
+  - command line tool and plugin-oriented Python framework for search and download from [multiple providers](https://eodag.readthedocs.io/en/stable/getting_started_guide/providers.html) including all DIAS
 
 ### Viewers & Portals
 - [**AWS/Sinergise "Sentinel Image Browser"**](http://sentinel-pds.s3-website.eu-central-1.amazonaws.com/browser.html)


### PR DESCRIPTION
Fixes the link to the providers list in documentation