### PR TITLE
Replace SciHub reference by CDSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A curated list of awesome tools, tutorials and APIs related to data from the [Co
 ### Data Hubs and National Mirrors
 Official datahubs and mirrors by the Copernicus partners and [Collaborative Ground Segment members](https://sentinels.copernicus.eu/web/sentinel/missions/collaborative/national-points-of-contact).
 
-- [**Copernicus Open Access Hub (SciHub)**](https://scihub.copernicus.eu/)
+- [**Copernicus Data Spaces Ecosystem (CDSE)**](https://dataspace.copernicus.eu/)
 - [**Australia National Mirror**](https://copernicus.nci.org.au/)
 - [**Austria National Mirror**](https://data.sentinel.zamg.ac.at/)
 - [**Czech Rebublic National Mirror**](https://dhr1.cesnet.cz/#/home)
@@ -75,7 +75,7 @@ Specific to Copernicus Sentinel data discovery, download and processing.
 
 ### Search & Download
 - [**`sentinelsat`**](https://github.com/sentinelsat/sentinelsat)
-  - search and download from any Datahub. Comes with an intuitive command line and a flexible Python API.
+  - search and download from any [DHuS](https://github.com/SentinelDataHub/)-powered Datahub. Comes with an intuitive command line and a flexible Python API.
 - [**`Sentinel-download`**](https://github.com/olivierhagolle/Sentinel-download)
   - download Sentinel-2 data from Copernicus SciHub. Supports download of sub-tiles in the old product format (PDS <14).
 - [**`peps_download`**](https://github.com/olivierhagolle/peps_download)


### PR DESCRIPTION
The [Copernicus Open Access Hub (SciHub)](https://scihub.copernicus.eu/) is history, long live the [Copernicus Data Space Ecosystem (CDSE)](https://dataspace.copernicus.eu/).

Supersedes https://github.com/kr-stn/awesome-sentinel/pull/37